### PR TITLE
Make extension discriminator clear

### DIFF
--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -105,7 +105,7 @@ function amo_width_valid(size : word_width) -> bool = {
 /* ****************************************************************** */
 union clause ast = LOADRES : (bool, bool, regidx, word_width, regidx)
 
-mapping clause encdec = LOADRES(aq, rl, rs1, size, rd) if amo_width_valid(size)
+mapping clause encdec = LOADRES(aq, rl, rs1, size, rd) if extension("A") & amo_width_valid(size)
   <-> 0b00010 @ bool_bits(aq) @ bool_bits(rl) @ 0b00000 @ rs1 @ 0b0 @ size_bits(size) @ rd @ 0b0101111 if amo_width_valid(size)
 
 
@@ -170,7 +170,7 @@ mapping clause assembly = LOADRES(aq, rl, rs1, size, rd)
 /* ****************************************************************** */
 union clause ast = STORECON : (bool, bool, regidx, regidx, word_width, regidx)
 
-mapping clause encdec = STORECON(aq, rl, rs2, rs1, size, rd) if amo_width_valid(size)
+mapping clause encdec = STORECON(aq, rl, rs2, rs1, size, rd) if extension("A") & amo_width_valid(size)
   <-> 0b00011 @ bool_bits(aq) @ bool_bits(rl) @ rs2 @ rs1 @ 0b0 @ size_bits(size) @ rd @ 0b0101111 if amo_width_valid(size)
 
 /* NOTE: Currently, we only EA if address translation is successful. This may need revisiting. */
@@ -268,7 +268,7 @@ mapping encdec_amoop : amoop <-> bits(5) = {
   AMOMAXU <-> 0b11100
 }
 
-mapping clause encdec = AMO(op, aq, rl, rs2, rs1, size, rd) if amo_width_valid(size)
+mapping clause encdec = AMO(op, aq, rl, rs2, rs1, size, rd) if extension("A") & amo_width_valid(size)
   <-> encdec_amoop(op) @ bool_bits(aq) @ bool_bits(rl) @ rs2 @ rs1 @ 0b0 @ size_bits(size) @ rd @ 0b0101111 if amo_width_valid(size)
 
 /* NOTE: Currently, we only EA if address translation is successful.

--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -123,7 +123,7 @@ function process_loadres(rd, addr, value, is_unsigned) =
   }
 
 function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
-  if haveAtomics() then {
+  if extension("A") then {
     /* Get the address, X(rs1) (no offset).
      * Extensions might perform additional checks on address validity.
      */
@@ -181,7 +181,7 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
      */
     X(rd) = zero_extend(0b1); RETIRE_SUCCESS
   } else {
-    if haveAtomics() then {
+    if extension("A") then {
       /* normal non-rmem case
        * rmem: SC is allowed to succeed (but might fail later)
        */
@@ -274,7 +274,7 @@ mapping clause encdec = AMO(op, aq, rl, rs2, rs1, size, rd) if amo_width_valid(s
 /* NOTE: Currently, we only EA if address translation is successful.
    This may need revisiting. */
 function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
-  if haveAtomics() then {
+  if extension("A") then {
     /* Get the address, X(rs1) (no offset).
      * Some extensions perform additional checks on address validity.
      */

--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -83,7 +83,7 @@ mapping encdec_mul_op : (bool, bool, bool) <-> bits(3) = {
 }
 
 /* for some reason the : bits(3) here is still necessary - BUG */
-mapping clause encdec = MUL(rs2, rs1, rd, high, signed1, signed2)
+mapping clause encdec = MUL(rs2, rs1, rd, high, signed1, signed2) if extension("M")
   <-> 0b0000001 @ rs2 @ rs1 @ encdec_mul_op(high, signed1, signed2) : bits(3) @ rd @ 0b0110011
 
 function clause execute (MUL(rs2, rs1, rd, high, signed1, signed2)) = {
@@ -117,7 +117,7 @@ mapping clause assembly = MUL(rs2, rs1, rd, high, signed1, signed2)
 /* ****************************************************************** */
 union clause ast = DIV : (regidx, regidx, regidx, bool)
 
-mapping clause encdec = DIV(rs2, rs1, rd, s)
+mapping clause encdec = DIV(rs2, rs1, rd, s) if extension("M")
   <-> 0b0000001 @ rs2 @ rs1 @ 0b10 @ bool_not_bits(s) @ rd @ 0b0110011
 
 function clause execute (DIV(rs2, rs1, rd, s)) = {
@@ -148,7 +148,7 @@ mapping clause assembly = DIV(rs2, rs1, rd, s)
 /* ****************************************************************** */
 union clause ast = REM : (regidx, regidx, regidx, bool)
 
-mapping clause encdec = REM(rs2, rs1, rd, s)
+mapping clause encdec = REM(rs2, rs1, rd, s) & extension("M")
   <-> 0b0000001 @ rs2 @ rs1 @ 0b11 @ bool_not_bits(s) @ rd @ 0b0110011
 
 function clause execute (REM(rs2, rs1, rd, s)) = {
@@ -173,7 +173,7 @@ mapping clause assembly = REM(rs2, rs1, rd, s)
 /* ****************************************************************** */
 union clause ast = MULW : (regidx, regidx, regidx)
 
-mapping clause encdec = MULW(rs2, rs1, rd)
+mapping clause encdec = MULW(rs2, rs1, rd) if extension("M")
       if sizeof(xlen) == 64
   <-> 0b0000001 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0111011
       if sizeof(xlen) == 64
@@ -203,7 +203,7 @@ mapping clause assembly = MULW(rs2, rs1, rd)
 /* ****************************************************************** */
 union clause ast = DIVW : (regidx, regidx, regidx, bool)
 
-mapping clause encdec = DIVW(rs2, rs1, rd, s)
+mapping clause encdec = DIVW(rs2, rs1, rd, s) if extension("M")
       if sizeof(xlen) == 64
   <-> 0b0000001 @ rs2 @ rs1 @ 0b10 @ bool_not_bits(s) @ rd @ 0b0111011
       if sizeof(xlen) == 64
@@ -233,7 +233,7 @@ mapping clause assembly = DIVW(rs2, rs1, rd, s)
 /* ****************************************************************** */
 union clause ast = REMW : (regidx, regidx, regidx, bool)
 
-mapping clause encdec = REMW(rs2, rs1, rd, s)
+mapping clause encdec = REMW(rs2, rs1, rd, s) if extension("M")
       if sizeof(xlen) == 64
   <-> 0b0000001 @ rs2 @ rs1 @ 0b11 @ bool_not_bits(s) @ rd @ 0b0111011
       if sizeof(xlen) == 64

--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -87,7 +87,7 @@ mapping clause encdec = MUL(rs2, rs1, rd, high, signed1, signed2)
   <-> 0b0000001 @ rs2 @ rs1 @ encdec_mul_op(high, signed1, signed2) : bits(3) @ rd @ 0b0110011
 
 function clause execute (MUL(rs2, rs1, rd, high, signed1, signed2)) = {
-  if haveMulDiv() | haveZmmul() then {
+  if extension("M") | haveZmmul() then {
     let rs1_val = X(rs1);
     let rs2_val = X(rs2);
     let rs1_int : int = if signed1 then signed(rs1_val) else unsigned(rs1_val);
@@ -121,7 +121,7 @@ mapping clause encdec = DIV(rs2, rs1, rd, s)
   <-> 0b0000001 @ rs2 @ rs1 @ 0b10 @ bool_not_bits(s) @ rd @ 0b0110011
 
 function clause execute (DIV(rs2, rs1, rd, s)) = {
-  if haveMulDiv() then {
+  if extension("M") then {
     let rs1_val = X(rs1);
     let rs2_val = X(rs2);
     let rs1_int : int = if s then signed(rs1_val) else unsigned(rs1_val);
@@ -152,7 +152,7 @@ mapping clause encdec = REM(rs2, rs1, rd, s)
   <-> 0b0000001 @ rs2 @ rs1 @ 0b11 @ bool_not_bits(s) @ rd @ 0b0110011
 
 function clause execute (REM(rs2, rs1, rd, s)) = {
-  if haveMulDiv() then {
+  if extension("M") then {
     let rs1_val = X(rs1);
     let rs2_val = X(rs2);
     let rs1_int : int = if s then signed(rs1_val) else unsigned(rs1_val);
@@ -179,7 +179,7 @@ mapping clause encdec = MULW(rs2, rs1, rd)
       if sizeof(xlen) == 64
 
 function clause execute (MULW(rs2, rs1, rd)) = {
-  if haveMulDiv() | haveZmmul() then {
+  if extension("M") | haveZmmul() then {
     let rs1_val = X(rs1)[31..0];
     let rs2_val = X(rs2)[31..0];
     let rs1_int : int = signed(rs1_val);
@@ -209,7 +209,7 @@ mapping clause encdec = DIVW(rs2, rs1, rd, s)
       if sizeof(xlen) == 64
 
 function clause execute (DIVW(rs2, rs1, rd, s)) = {
-  if haveMulDiv() then {
+  if extension("M") then {
     let rs1_val = X(rs1)[31..0];
     let rs2_val = X(rs2)[31..0];
     let rs1_int : int = if s then signed(rs1_val) else unsigned(rs1_val);
@@ -239,7 +239,7 @@ mapping clause encdec = REMW(rs2, rs1, rd, s)
       if sizeof(xlen) == 64
 
 function clause execute (REMW(rs2, rs1, rd, s)) = {
-  if haveMulDiv() then {
+  if extension("M") then {
     let rs1_val = X(rs1)[31..0];
     let rs2_val = X(rs2)[31..0];
     let rs1_int : int = if s then signed(rs1_val) else unsigned(rs1_val);

--- a/model/riscv_insts_mext.sail
+++ b/model/riscv_insts_mext.sail
@@ -148,7 +148,7 @@ mapping clause assembly = DIV(rs2, rs1, rd, s)
 /* ****************************************************************** */
 union clause ast = REM : (regidx, regidx, regidx, bool)
 
-mapping clause encdec = REM(rs2, rs1, rd, s) & extension("M")
+mapping clause encdec = REM(rs2, rs1, rd, s) if extension("M")
   <-> 0b0000001 @ rs2 @ rs1 @ 0b11 @ bool_not_bits(s) @ rd @ 0b0110011
 
 function clause execute (REM(rs2, rs1, rd, s)) = {
@@ -173,10 +173,10 @@ mapping clause assembly = REM(rs2, rs1, rd, s)
 /* ****************************************************************** */
 union clause ast = MULW : (regidx, regidx, regidx)
 
-mapping clause encdec = MULW(rs2, rs1, rd) if extension("M")
-      if sizeof(xlen) == 64
+mapping clause encdec = MULW(rs2, rs1, rd)
+      if extension("M") & sizeof(xlen) == 64
   <-> 0b0000001 @ rs2 @ rs1 @ 0b000 @ rd @ 0b0111011
-      if sizeof(xlen) == 64
+      if extension("M") & sizeof(xlen) == 64
 
 function clause execute (MULW(rs2, rs1, rd)) = {
   if extension("M") | haveZmmul() then {
@@ -203,10 +203,10 @@ mapping clause assembly = MULW(rs2, rs1, rd)
 /* ****************************************************************** */
 union clause ast = DIVW : (regidx, regidx, regidx, bool)
 
-mapping clause encdec = DIVW(rs2, rs1, rd, s) if extension("M")
-      if sizeof(xlen) == 64
+mapping clause encdec = DIVW(rs2, rs1, rd, s)
+      if extension("M") & sizeof(xlen) == 64
   <-> 0b0000001 @ rs2 @ rs1 @ 0b10 @ bool_not_bits(s) @ rd @ 0b0111011
-      if sizeof(xlen) == 64
+      if extension("M") & sizeof(xlen) == 64
 
 function clause execute (DIVW(rs2, rs1, rd, s)) = {
   if extension("M") then {
@@ -233,10 +233,10 @@ mapping clause assembly = DIVW(rs2, rs1, rd, s)
 /* ****************************************************************** */
 union clause ast = REMW : (regidx, regidx, regidx, bool)
 
-mapping clause encdec = REMW(rs2, rs1, rd, s) if extension("M")
-      if sizeof(xlen) == 64
+mapping clause encdec = REMW(rs2, rs1, rd, s)
+      if extension("M") & sizeof(xlen) == 64
   <-> 0b0000001 @ rs2 @ rs1 @ 0b11 @ bool_not_bits(s) @ rd @ 0b0111011
-      if sizeof(xlen) == 64
+      if extension("M") & sizeof(xlen) == 64
 
 function clause execute (REMW(rs2, rs1, rd, s)) = {
   if extension("M") then {


### PR DESCRIPTION
Implement #4
For this pull request i work on "A" and "M" extension. 
I've cloned your JSON branch and worked from that so I can continue what you've already done.

> I have already implemented all of the necessary changes. Look at the "JSON" branch in this repository. Further work here should probably be on top of that branch.

Of course, I've noticed that you've already worked on the "V" and "Zbkb" extension. And that really helped me to recognise the "M" and "A" extensions.