### PR TITLE
Add tags to all instructions also make them to clearly express their purpose

### DIFF
--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -74,6 +74,10 @@
 /* ****************************************************************** */
 // Some print utils for lr/sc.
 
+
+include "riscv_insts_helper.sail"
+
+
 function aqrl_str(aq : bool, rl : bool) -> string =
   match (aq, rl) {
     (false, false) => "",
@@ -105,7 +109,7 @@ function amo_width_valid(size : word_width) -> bool = {
 /* ****************************************************************** */
 union clause ast = LOADRES : (bool, bool, regidx, word_width, regidx)
 
-mapping clause encdec = LOADRES(aq, rl, rs1, size, rd) if amo_width_valid(size)
+mapping clause encdec = LOADRES(aq, rl, rs1, size, rd) if extension("A") & amo_width_valid(size) 
   <-> 0b00010 @ bool_bits(aq) @ bool_bits(rl) @ 0b00000 @ rs1 @ 0b0 @ size_bits(size) @ rd @ 0b0101111 if amo_width_valid(size)
 
 
@@ -123,7 +127,7 @@ function process_loadres(rd, addr, value, is_unsigned) =
   }
 
 function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
-  if haveAtomics() then {
+  if extension("A") then {
     /* Get the address, X(rs1) (no offset).
      * Extensions might perform additional checks on address validity.
      */
@@ -164,14 +168,14 @@ function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
   }
 }
 
-mapping clause assembly = LOADRES(aq, rl, rs1, size, rd)
+mapping clause assembly = LOADRES(aq, rl, rs1, size, rd) if  extension("A") 
   <-> "lr." ^ size_mnemonic(size) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1)
 
 /* ****************************************************************** */
 union clause ast = STORECON : (bool, bool, regidx, regidx, word_width, regidx)
 
-mapping clause encdec = STORECON(aq, rl, rs2, rs1, size, rd) if amo_width_valid(size)
-  <-> 0b00011 @ bool_bits(aq) @ bool_bits(rl) @ rs2 @ rs1 @ 0b0 @ size_bits(size) @ rd @ 0b0101111 if amo_width_valid(size)
+mapping clause encdec = STORECON(aq, rl, rs2, rs1, size, rd) if extension("A") & amo_width_valid(size)
+  <-> 0b00011 @ bool_bits(aq) @ bool_bits(rl) @ rs2 @ rs1 @ 0b0 @ size_bits(size) @ rd @ 0b0101111 if  extension("A") & amo_width_valid(size) 
 
 /* NOTE: Currently, we only EA if address translation is successful. This may need revisiting. */
 function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
@@ -181,7 +185,7 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
      */
     X(rd) = zero_extend(0b1); RETIRE_SUCCESS
   } else {
-    if haveAtomics() then {
+    if extension("A") then {
       /* normal non-rmem case
        * rmem: SC is allowed to succeed (but might fail later)
        */
@@ -250,7 +254,7 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
   }
 }
 
-mapping clause assembly = STORECON(aq, rl, rs2, rs1, size, rd)
+mapping clause assembly = STORECON(aq, rl, rs2, rs1, size, rd) if  extension("A") &
   <-> "sc." ^ size_mnemonic(size) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs1) ^ sep() ^ reg_name(rs2)
 
 /* ****************************************************************** */
@@ -274,7 +278,7 @@ mapping clause encdec = AMO(op, aq, rl, rs2, rs1, size, rd) if amo_width_valid(s
 /* NOTE: Currently, we only EA if address translation is successful.
    This may need revisiting. */
 function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
-  if haveAtomics() then {
+  if extension("A") then {
     /* Get the address, X(rs1) (no offset).
      * Some extensions perform additional checks on address validity.
      */
@@ -375,5 +379,5 @@ mapping amo_mnemonic : amoop <-> string = {
   AMOMAXU <-> "amomaxu"
 }
 
-mapping clause assembly = AMO(op, aq, rl, rs2, rs1, width, rd)
+mapping clause assembly = AMO(op, aq, rl, rs2, rs1, width, rd) if extension("A")
   <-> amo_mnemonic(op) ^ "." ^ size_mnemonic(width) ^ maybe_aq(aq) ^ maybe_rl(rl) ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs2) ^ sep() ^ "(" ^ reg_name(rs1) ^ ")"

--- a/model/riscv_insts_cext.sail
+++ b/model/riscv_insts_cext.sail
@@ -77,23 +77,26 @@
  */
 
 /* ****************************************************************** */
+
+include "riscv_insts_helper.sail"
+
 union clause ast = C_NOP : unit
 
-mapping clause encdec_compressed = C_NOP()
-  <-> 0b000 @ 0b0 @ 0b00000 @ 0b00000 @ 0b01
+mapping clause encdec_compressed = C_NOP() if extension("C")
+  <-> 0b000 @ 0b0 @ 0b00000 @ 0b00000 @ 0b01  if extension("C")
 
 function clause execute C_NOP() = RETIRE_SUCCESS
 
-mapping clause assembly = C_NOP() <-> "c.nop"
+mapping clause assembly = C_NOP() <-> "c.nop" if extension("C")
 
 /* ****************************************************************** */
 
 union clause ast = C_ADDI4SPN : (cregidx, bits(8))
 
 mapping clause encdec_compressed = C_ADDI4SPN(rd, nz96 @ nz54 @ nz3 @ nz2)
-      if nz96 @ nz54 @ nz3 @ nz2 != 0b00000000
+      if nz96 @ nz54 @ nz3 @ nz2 != 0b00000000 & extension("C")
   <-> 0b000 @ nz54 : bits(2) @ nz96 : bits(4) @ nz2 : bits(1) @ nz3 : bits(1) @ rd : cregidx @ 0b00
-      if nz96 @ nz54 @ nz3 @ nz2 != 0b00000000
+      if nz96 @ nz54 @ nz3 @ nz2 != 0b00000000 & extension("C")
 
 function clause execute (C_ADDI4SPN(rdc, nzimm)) = {
   let imm : bits(12) = (0b00 @ nzimm @ 0b00);
@@ -102,15 +105,15 @@ function clause execute (C_ADDI4SPN(rdc, nzimm)) = {
 }
 
 mapping clause assembly = C_ADDI4SPN(rdc, nzimm)
-      if nzimm != 0b00000000
+      if nzimm != 0b00000000 & extension("C")
   <-> "c.addi4spn" ^ spc() ^ creg_name(rdc) ^ sep() ^ hex_bits_10(nzimm @ 0b00)
-      if nzimm != 0b00000000
+      if nzimm != 0b00000000 & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_LW : (bits(5), cregidx, cregidx)
 
-mapping clause encdec_compressed = C_LW(ui6 @ ui53 @ ui2, rs1, rd)
-  <-> 0b010 @ ui53 : bits(3) @ rs1 : cregidx @ ui2 : bits(1) @ ui6 : bits(1) @ rd : cregidx @ 0b00
+mapping clause encdec_compressed = C_LW(ui6 @ ui53 @ ui2, rs1, rd) if extension("C")
+  <-> 0b010 @ ui53 : bits(3) @ rs1 : cregidx @ ui2 : bits(1) @ ui6 : bits(1) @ rd : cregidx @ 0b00 if extension("C")
 
 function clause execute (C_LW(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
@@ -119,16 +122,16 @@ function clause execute (C_LW(uimm, rsc, rdc)) = {
   execute(LOAD(imm, rs, rd, false, WORD, false, false))
 }
 
-mapping clause assembly = C_LW(uimm, rsc, rdc)
-  <-> "c.lw" ^ spc() ^ creg_name(rdc) ^ sep() ^ creg_name(rsc) ^ sep() ^ hex_bits_7(uimm @ 0b00)
+mapping clause assembly = C_LW(uimm, rsc, rdc) if extension("C")
+  <-> "c.lw" ^ spc() ^ creg_name(rdc) ^ sep() ^ creg_name(rsc) ^ sep() ^ hex_bits_7(uimm @ 0b00) if extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_LD : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_LD(ui76 @ ui53, rs1, rd)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
   <-> 0b011 @ ui53 : bits(3) @ rs1 : cregidx @ ui76 : bits(2) @ rd : cregidx @ 0b00
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
 
 function clause execute (C_LD(uimm, rsc, rdc)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -138,15 +141,15 @@ function clause execute (C_LD(uimm, rsc, rdc)) = {
 }
 
 mapping clause assembly = C_LD(uimm, rsc, rdc)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
   <-> "c.ld" ^ spc() ^ creg_name(rdc) ^ sep() ^ creg_name(rsc) ^ sep() ^ hex_bits_8(uimm @ 0b000)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_SW : (bits(5), cregidx, cregidx)
 
-mapping clause encdec_compressed = C_SW(ui6 @ ui53 @ ui2, rs1, rs2)
-  <-> 0b110 @ ui53 : bits(3) @ rs1 : cregidx @ ui2 : bits(1) @ ui6 : bits(1) @ rs2 : cregidx @ 0b00
+mapping clause encdec_compressed = C_SW(ui6 @ ui53 @ ui2, rs1, rs2) if extension("C")
+  <-> 0b110 @ ui53 : bits(3) @ rs1 : cregidx @ ui2 : bits(1) @ ui6 : bits(1) @ rs2 : cregidx @ 0b00 if extension("C")
 
 function clause execute (C_SW(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
@@ -155,16 +158,16 @@ function clause execute (C_SW(uimm, rsc1, rsc2)) = {
   execute(STORE(imm, rs2, rs1, WORD, false, false))
 }
 
-mapping clause assembly = C_SW(uimm, rsc1, rsc2)
-  <-> "c.sw" ^ spc() ^ creg_name(rsc1) ^ sep() ^ creg_name(rsc2) ^ sep() ^ hex_bits_7(uimm @ 0b00)
+mapping clause assembly = C_SW(uimm, rsc1, rsc2) if extension("C")
+  <-> "c.sw" ^ spc() ^ creg_name(rsc1) ^ sep() ^ creg_name(rsc2) ^ sep() ^ hex_bits_7(uimm @ 0b00) if extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_SD : (bits(5), cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SD(ui76 @ ui53, rs1, rs2)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
   <-> 0b111 @ ui53 : bits(3) @ rs1 : bits(3) @ ui76 : bits(2) @ rs2 : bits(3) @ 0b00
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
 
 function clause execute (C_SD(uimm, rsc1, rsc2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -174,17 +177,17 @@ function clause execute (C_SD(uimm, rsc1, rsc2)) = {
 }
 
 mapping clause assembly = C_SD(uimm, rsc1, rsc2)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
   <-> "c.sd" ^ spc() ^ creg_name(rsc1) ^ sep() ^ creg_name(rsc2) ^ sep() ^ hex_bits_8(uimm @ 0b000)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_ADDI : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_ADDI(nzi5 @ nzi40, rsd)
-      if nzi5 @ nzi40 != 0b000000 & rsd != zreg
+      if nzi5 @ nzi40 != 0b000000 & rsd != zreg & extension("C")
   <-> 0b000 @ nzi5 : bits(1) @ rsd : regidx @ nzi40 : bits(5) @ 0b01
-      if nzi5 @ nzi40 != 0b000000 & rsd != zreg
+      if nzi5 @ nzi40 != 0b000000 & rsd != zreg & extension("C")
 
 function clause execute (C_ADDI(nzi, rsd)) = {
   let imm : bits(12) = sign_extend(nzi);
@@ -192,49 +195,49 @@ function clause execute (C_ADDI(nzi, rsd)) = {
 }
 
 mapping clause assembly = C_ADDI(nzi, rsd)
-      if nzi != 0b000000 & rsd != zreg
+      if nzi != 0b000000 & rsd != zreg & extension("C")
   <-> "c.addi" ^ spc() ^ reg_name(rsd) ^ sep() ^ hex_bits_6(nzi)
-      if nzi != 0b000000 & rsd != zreg
+      if nzi != 0b000000 & rsd != zreg & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_JAL : (bits(11))
 
 mapping clause encdec_compressed = C_JAL(i11 @ i10 @ i98 @ i7 @ i6 @ i5 @ i4 @ i31)
-      if sizeof(xlen) == 32
+      if sizeof(xlen) == 32 & extension("C")
   <-> 0b001 @ i11 : bits(1) @ i4 : bits(1) @ i98 : bits(2) @ i10 : bits(1) @ i6 : bits(1) @ i7 : bits(1) @ i31 : bits(3) @ i5 : bits(1) @ 0b01
-      if sizeof(xlen) == 32
+      if sizeof(xlen) == 32 & extension("C")
 
 function clause execute (C_JAL(imm)) =
   execute(RISCV_JAL(sign_extend(imm @ 0b0), ra))
 
 mapping clause assembly = C_JAL(imm)
-      if sizeof(xlen) == 32
+      if sizeof(xlen) == 32 & extension("C")
   <-> "c.jal" ^ spc() ^ hex_bits_12(imm @ 0b0)
-      if sizeof(xlen) == 32
+      if sizeof(xlen) == 32 & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_ADDIW : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_ADDIW(imm5 @ imm40, rsd)
-      if rsd != zreg & sizeof(xlen) == 64
+      if rsd != zreg & sizeof(xlen) == 64 & extension("C")
   <-> 0b001 @ imm5 : bits(1) @ rsd : regidx @ imm40 : bits(5) @ 0b01
-      if rsd != zreg & sizeof(xlen) == 64
+      if rsd != zreg & sizeof(xlen) == 64 & extension("C")
 
 function clause execute (C_ADDIW(imm, rsd)) =
   execute(ADDIW(sign_extend(imm), rsd, rsd))
 
 mapping clause assembly = C_ADDIW(imm, rsd)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
   <-> "c.addiw" ^ spc() ^ reg_name(rsd) ^ sep() ^ hex_bits_6(imm)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_LI : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LI(imm5 @ imm40, rd)
-      if rd != zreg
+      if rd != zreg & extension("C")
   <-> 0b010 @ imm5 : bits(1) @ rd : regidx @ imm40 : bits(5) @ 0b01
-      if rd != zreg
+      if rd != zreg & extension("C")
 
 function clause execute (C_LI(imm, rd)) = {
   let imm : bits(12) = sign_extend(imm);
@@ -242,17 +245,17 @@ function clause execute (C_LI(imm, rd)) = {
 }
 
 mapping clause assembly = C_LI(imm, rd)
-      if rd != zreg
+      if rd != zreg & extension("C")
   <-> "c.li" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(imm)
-      if rd != zreg
+      if rd != zreg & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_ADDI16SP : (bits(6))
 
 mapping clause encdec_compressed = C_ADDI16SP(nzi9 @ nzi87 @ nzi6 @ nzi5 @ nzi4)
-      if nzi9 @ nzi87 @ nzi6 @ nzi5 @ nzi4 != 0b000000
+      if nzi9 @ nzi87 @ nzi6 @ nzi5 @ nzi4 != 0b000000 & extension("C")
   <-> 0b011 @ nzi9 : bits(1) @ /* x2 */ 0b00010 @ nzi4 : bits(1) @ nzi6 : bits(1) @ nzi87 : bits(2) @ nzi5 : bits(1) @ 0b01
-      if nzi9 @ nzi87 @ nzi6 @ nzi5 @ nzi4 != 0b000000
+      if nzi9 @ nzi87 @ nzi6 @ nzi5 @ nzi4 != 0b000000 & extension("C")
 
 function clause execute (C_ADDI16SP(imm)) = {
   let imm : bits(12) = sign_extend(imm @ 0x0);
@@ -260,17 +263,17 @@ function clause execute (C_ADDI16SP(imm)) = {
 }
 
 mapping clause assembly = C_ADDI16SP(imm)
-      if imm != 0b000000
+      if imm != 0b000000 & extension("C")
   <-> "c.addi16sp" ^ spc() ^ hex_bits_6(imm)
-      if imm != 0b000000
+      if imm != 0b000000 & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_LUI : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LUI(imm17 @ imm1612, rd)
-      if rd != zreg & rd != sp & imm17 @ imm1612 != 0b000000
+      if rd != zreg & rd != sp & imm17 @ imm1612 != 0b000000 & extension("C")
   <-> 0b011 @ imm17 : bits(1) @ rd : regidx @ imm1612 : bits(5) @ 0b01
-      if rd != zreg & rd != sp & imm17 @ imm1612 != 0b000000
+      if rd != zreg & rd != sp & imm17 @ imm1612 != 0b000000 & extension("C")
 
 function clause execute (C_LUI(imm, rd)) = {
   let res : bits(20) = sign_extend(imm);
@@ -278,17 +281,17 @@ function clause execute (C_LUI(imm, rd)) = {
 }
 
 mapping clause assembly = C_LUI(imm, rd)
-      if rd != zreg & rd != sp & imm != 0b000000
+      if rd != zreg & rd != sp & imm != 0b000000 & extension("C")
   <-> "c.lui" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(imm)
-      if rd != zreg & rd != sp & imm != 0b000000
+      if rd != zreg & rd != sp & imm != 0b000000 & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_SRLI : (bits(6), cregidx)
 
 mapping clause encdec_compressed = C_SRLI(nzui5 @ nzui40, rsd)
-      if nzui5 @ nzui40 != 0b000000
+      if nzui5 @ nzui40 != 0b000000 & extension("C")
   <-> 0b100 @ nzui5 : bits(1) @ 0b00 @ rsd : cregidx @ nzui40 : bits(5) @ 0b01
-      if nzui5 @ nzui40 != 0b000000
+      if nzui5 @ nzui40 != 0b000000 & extension("C")
 
 function clause execute (C_SRLI(shamt, rsd)) = {
   let rsd = creg2reg_idx(rsd);
@@ -296,17 +299,17 @@ function clause execute (C_SRLI(shamt, rsd)) = {
 }
 
 mapping clause assembly = C_SRLI(shamt, rsd)
-      if shamt != 0b000000
+      if shamt != 0b000000 & extension("C") 
   <-> "c.srli" ^ spc() ^ creg_name(rsd) ^ sep() ^ hex_bits_6(shamt)
-      if shamt != 0b000000
+      if shamt != 0b000000 & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_SRAI : (bits(6), cregidx)
 
 mapping clause encdec_compressed = C_SRAI(nzui5 @ nzui40, rsd)
-      if nzui5 @ nzui40 != 0b000000
+      if nzui5 @ nzui40 != 0b000000 & extension("C")
   <-> 0b100 @ nzui5 : bits(1) @ 0b01 @ rsd : cregidx @ nzui40 : bits(5) @ 0b01
-      if nzui5 @ nzui40 != 0b000000
+      if nzui5 @ nzui40 != 0b000000 & extension("C")
 
 function clause execute (C_SRAI(shamt, rsd)) = {
   let rsd = creg2reg_idx(rsd);
@@ -314,29 +317,29 @@ function clause execute (C_SRAI(shamt, rsd)) = {
 }
 
 mapping clause assembly = C_SRAI(shamt, rsd)
-      if shamt != 0b000000
+      if shamt != 0b000000 & extension("C")
   <-> "c.srai" ^ spc() ^ creg_name(rsd) ^ sep() ^ hex_bits_6(shamt)
-      if shamt != 0b000000
+      if shamt != 0b000000 & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_ANDI : (bits(6), cregidx)
 
-mapping clause encdec_compressed = C_ANDI(i5 @ i40, rsd)
-  <-> 0b100 @ i5 : bits(1) @ 0b10 @ rsd : cregidx @ i40 : bits(5) @ 0b01
+mapping clause encdec_compressed = C_ANDI(i5 @ i40, rsd) if extension("C")
+  <-> 0b100 @ i5 : bits(1) @ 0b10 @ rsd : cregidx @ i40 : bits(5) @ 0b01 if extension("C")
 
 function clause execute (C_ANDI(imm, rsd)) = {
   let rsd = creg2reg_idx(rsd);
   execute(ITYPE(sign_extend(imm), rsd, rsd, RISCV_ANDI))
 }
 
-mapping clause assembly = C_ANDI(imm, rsd)
-  <-> "c.andi" ^ spc() ^ creg_name(rsd) ^ sep() ^ hex_bits_6(imm)
+mapping clause assembly = C_ANDI(imm, rsd) if extension("C")
+  <-> "c.andi" ^ spc() ^ creg_name(rsd) ^ sep() ^ hex_bits_6(imm) if extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_SUB : (cregidx, cregidx)
 
-mapping clause encdec_compressed = C_SUB(rsd, rs2)
-  <-> 0b100 @ 0b0 @ 0b11 @ rsd : cregidx @ 0b00 @ rs2 : cregidx @ 0b01
+mapping clause encdec_compressed = C_SUB(rsd, rs2) if extension("C")
+  <-> 0b100 @ 0b0 @ 0b11 @ rsd : cregidx @ 0b00 @ rs2 : cregidx @ 0b01 if extension("C")
 
 function clause execute (C_SUB(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
@@ -344,29 +347,29 @@ function clause execute (C_SUB(rsd, rs2)) = {
   execute(RTYPE(rs2, rsd, rsd, RISCV_SUB))
 }
 
-mapping clause assembly = C_SUB(rsd, rs2)
-  <-> "c.sub" ^ spc() ^ creg_name(rsd) ^ sep() ^ creg_name(rs2)
+mapping clause assembly = C_SUB(rsd, rs2) if extension("C")
+  <-> "c.sub" ^ spc() ^ creg_name(rsd) ^ sep() ^ creg_name(rs2) if extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_XOR : (cregidx, cregidx)
 
-mapping clause encdec_compressed = C_XOR(rsd, rs2)
-  <-> 0b100 @ 0b0 @ 0b11 @ rsd : cregidx @ 0b01 @ rs2 : cregidx @ 0b01
-
+mapping clause encdec_compressed = C_XOR(rsd, rs2) if extension("C")
+  <-> 0b100 @ 0b0 @ 0b11 @ rsd : cregidx @ 0b01 @ rs2 : cregidx @ 0b01 if extension("C")
+ 
 function clause execute (C_XOR(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
   let rs2 = creg2reg_idx(rs2);
   execute(RTYPE(rs2, rsd, rsd, RISCV_XOR))
 }
 
-mapping clause assembly = C_XOR(rsd, rs2)
-  <-> "c.xor" ^ spc() ^ creg_name(rsd) ^ sep() ^ creg_name(rs2)
+mapping clause assembly = C_XOR(rsd, rs2) if extension("C")
+  <-> "c.xor" ^ spc() ^ creg_name(rsd) ^ sep() ^ creg_name(rs2) if extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_OR : (cregidx, cregidx)
 
-mapping clause encdec_compressed = C_OR(rsd, rs2)
-  <-> 0b100 @ 0b0 @ 0b11 @ rsd : cregidx @ 0b10 @ rs2 : cregidx @ 0b01
+mapping clause encdec_compressed = C_OR(rsd, rs2) if extension("C")
+  <-> 0b100 @ 0b0 @ 0b11 @ rsd : cregidx @ 0b10 @ rs2 : cregidx @ 0b01 if extension("C")
 
 function clause execute (C_OR(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
@@ -374,14 +377,14 @@ function clause execute (C_OR(rsd, rs2)) = {
   execute(RTYPE(rs2, rsd, rsd, RISCV_OR))
 }
 
-mapping clause assembly = C_OR(rsd, rs2)
-  <-> "c.or" ^ spc() ^ creg_name(rsd) ^ sep() ^ creg_name(rs2)
+mapping clause assembly = C_OR(rsd, rs2) if extension("C")
+  <-> "c.or" ^ spc() ^ creg_name(rsd) ^ sep() ^ creg_name(rs2) if extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_AND : (cregidx, cregidx)
 
-mapping clause encdec_compressed = C_AND(rsd, rs2)
-  <-> 0b100 @ 0b0 @ 0b11 @ rsd : cregidx @ 0b11 @ rs2 : cregidx @ 0b01
+mapping clause encdec_compressed = C_AND(rsd, rs2) if extension("C")
+  <-> 0b100 @ 0b0 @ 0b11 @ rsd : cregidx @ 0b11 @ rs2 : cregidx @ 0b01 if extension("C")
 
 function clause execute (C_AND(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
@@ -389,16 +392,16 @@ function clause execute (C_AND(rsd, rs2)) = {
   execute(RTYPE(rs2, rsd, rsd, RISCV_AND))
 }
 
-mapping clause assembly = C_AND(rsd, rs2)
-  <-> "c.and" ^ spc() ^ creg_name(rsd) ^ sep() ^ creg_name(rs2)
+mapping clause assembly = C_AND(rsd, rs2) if extension("C")
+  <-> "c.and" ^ spc() ^ creg_name(rsd) ^ sep() ^ creg_name(rs2) if extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_SUBW : (cregidx, cregidx)
 
 mapping clause encdec_compressed = C_SUBW(rsd, rs2)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
   <-> 0b100 @ 0b1 @ 0b11 @ rsd : cregidx @ 0b00 @ rs2 : cregidx @ 0b01
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
 
 function clause execute (C_SUBW(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
@@ -407,17 +410,17 @@ function clause execute (C_SUBW(rsd, rs2)) = {
 }
 
 mapping clause assembly = C_SUBW(rsd, rs2)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
   <-> "c.subw" ^ spc() ^ creg_name(rsd) ^ sep() ^ creg_name(rs2)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
 
 /* ****************************************************************** */
-union clause ast = C_ADDW : (cregidx, cregidx)
+union clause ast = C_ADDW : (cregidx, cregidx) 
 
 mapping clause encdec_compressed = C_ADDW(rsd, rs2)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
   <-> 0b100 @ 0b1 @ 0b11 @ rsd : cregidx @ 0b01 @ rs2 : cregidx @ 0b01
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
 
 function clause execute (C_ADDW(rsd, rs2)) = {
   let rsd = creg2reg_idx(rsd);
@@ -426,69 +429,69 @@ function clause execute (C_ADDW(rsd, rs2)) = {
 }
 
 mapping clause assembly = C_ADDW(rsd, rs2)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
   <-> "c.addw" ^ spc() ^ creg_name(rsd) ^ sep() ^ creg_name(rs2)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_J : (bits(11))
 
-mapping clause encdec_compressed = C_J(i11 @ i10 @ i98 @ i7 @ i6 @ i5 @ i4 @ i31)
-  <-> 0b101 @ i11 : bits(1) @ i4 : bits(1) @ i98 : bits(2) @ i10 : bits(1) @ i6 : bits(1) @ i7 : bits(1) @ i31 : bits(3) @ i5 : bits(1) @ 0b01
+mapping clause encdec_compressed = C_J(i11 @ i10 @ i98 @ i7 @ i6 @ i5 @ i4 @ i31) if extension("C")
+  <-> 0b101 @ i11 : bits(1) @ i4 : bits(1) @ i98 : bits(2) @ i10 : bits(1) @ i6 : bits(1) @ i7 : bits(1) @ i31 : bits(3) @ i5 : bits(1) @ 0b01 if extension("C")
 
 function clause execute (C_J(imm)) =
   execute(RISCV_JAL(sign_extend(imm @ 0b0), zreg))
 
-mapping clause assembly = C_J(imm)
-  <-> "c.j" ^ spc() ^ hex_bits_11(imm)
+mapping clause assembly = C_J(imm) if extension("C")
+  <-> "c.j" ^ spc() ^ hex_bits_11(imm) if extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_BEQZ : (bits(8), cregidx)
 
-mapping clause encdec_compressed = C_BEQZ(i8 @ i76 @ i5 @ i43 @ i21, rs)
-  <-> 0b110 @ i8 : bits(1) @ i43 : bits(2) @ rs : cregidx @ i76 : bits(2) @ i21 : bits(2) @ i5 : bits(1) @ 0b01
+mapping clause encdec_compressed = C_BEQZ(i8 @ i76 @ i5 @ i43 @ i21, rs) if extension("C") 
+  <-> 0b110 @ i8 : bits(1) @ i43 : bits(2) @ rs : cregidx @ i76 : bits(2) @ i21 : bits(2) @ i5 : bits(1) @ 0b01 if extension("C")
 
 function clause execute (C_BEQZ(imm, rs)) =
   execute(BTYPE(sign_extend(imm @ 0b0), zreg, creg2reg_idx(rs), RISCV_BEQ))
 
-mapping clause assembly = C_BEQZ(imm, rs)
-  <-> "c.beqz" ^ spc() ^ creg_name(rs) ^ sep() ^ hex_bits_8(imm)
+mapping clause assembly = C_BEQZ(imm, rs) if extension("C")
+  <-> "c.beqz" ^ spc() ^ creg_name(rs) ^ sep() ^ hex_bits_8(imm) if extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_BNEZ : (bits(8), cregidx)
 
-mapping clause encdec_compressed = C_BNEZ(i8 @ i76 @ i5 @ i43 @ i21, rs)
-  <-> 0b111 @ i8 : bits(1) @ i43 : bits(2) @ rs : cregidx @ i76 : bits(2) @ i21 : bits(2) @ i5 : bits(1) @ 0b01
+mapping clause encdec_compressed = C_BNEZ(i8 @ i76 @ i5 @ i43 @ i21, rs) if extension("C")
+  <-> 0b111 @ i8 : bits(1) @ i43 : bits(2) @ rs : cregidx @ i76 : bits(2) @ i21 : bits(2) @ i5 : bits(1) @ 0b01 if extension("C")
 
 function clause execute (C_BNEZ(imm, rs)) =
   execute(BTYPE(sign_extend(imm @ 0b0), zreg, creg2reg_idx(rs), RISCV_BNE))
 
-mapping clause assembly = C_BNEZ(imm, rs)
-  <-> "c.bnez" ^ spc() ^ creg_name(rs) ^ sep() ^ hex_bits_8(imm)
+mapping clause assembly = C_BNEZ(imm, rs) if extension("C")
+  <-> "c.bnez" ^ spc() ^ creg_name(rs) ^ sep() ^ hex_bits_8(imm) if extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_SLLI : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_SLLI(nzui5 @ nzui40, rsd)
-      if nzui5 @ nzui40 != 0b000000 & rsd != zreg & (sizeof(xlen) == 64 | nzui5 == 0b0)
+      if nzui5 @ nzui40 != 0b000000 & rsd != zreg & (sizeof(xlen) == 64 | nzui5 == 0b0) & extension("C")
   <-> 0b000 @ nzui5 : bits(1) @ rsd : regidx @ nzui40 : bits(5) @ 0b10
-      if nzui5 @ nzui40 != 0b000000 & rsd != zreg & (sizeof(xlen) == 64 | nzui5 == 0b0)
+      if nzui5 @ nzui40 != 0b000000 & rsd != zreg & (sizeof(xlen) == 64 | nzui5 == 0b0) & extension("C")
 
 function clause execute (C_SLLI(shamt, rsd)) =
   execute(SHIFTIOP(shamt, rsd, rsd, RISCV_SLLI))
 
 mapping clause assembly = C_SLLI(shamt, rsd)
-      if shamt != 0b000000 & rsd != zreg
+      if shamt != 0b000000 & rsd != zreg & extension("C")
   <-> "c.slli" ^ spc() ^ reg_name(rsd) ^ sep() ^ hex_bits_6(shamt)
-      if shamt != 0b000000 & rsd != zreg
+      if shamt != 0b000000 & rsd != zreg & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_LWSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LWSP(ui76 @ ui5 @ ui42, rd)
-      if rd != zreg
+      if rd != zreg & extension("C")
   <-> 0b010 @ ui5 : bits(1) @ rd : regidx @ ui42 : bits(3) @ ui76 : bits(2) @ 0b10
-      if rd != zreg
+      if rd != zreg & extension("C")
 
 function clause execute (C_LWSP(uimm, rd)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
@@ -496,17 +499,17 @@ function clause execute (C_LWSP(uimm, rd)) = {
 }
 
 mapping clause assembly = C_LWSP(uimm, rd)
-      if rd != zreg
+      if rd != zreg & extension("C")
   <-> "c.lwsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm)
-      if rd != zreg
+      if rd != zreg & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_LDSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_LDSP(ui86 @ ui5 @ ui43, rd)
-      if rd != zreg & sizeof(xlen) == 64
+      if rd != zreg & sizeof(xlen) == 64 & extension("C")
   <-> 0b011 @ ui5 : bits(1) @ rd : regidx @ ui43 : bits(2) @ ui86 : bits(3) @ 0b10
-      if rd != zreg & sizeof(xlen) == 64
+      if rd != zreg & sizeof(xlen) == 64 & extension("C")
 
 function clause execute (C_LDSP(uimm, rd)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -514,31 +517,31 @@ function clause execute (C_LDSP(uimm, rd)) = {
 }
 
 mapping clause assembly = C_LDSP(uimm, rd)
-      if rd != zreg & sizeof(xlen) == 64
+      if rd != zreg & sizeof(xlen) == 64 & extension("C")
   <-> "c.ldsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm)
-      if rd != zreg & sizeof(xlen) == 64
+      if rd != zreg & sizeof(xlen) == 64 & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_SWSP : (bits(6), regidx)
 
-mapping clause encdec_compressed = C_SWSP(ui76 @ ui52, rs2)
-  <-> 0b110 @ ui52 : bits(4) @ ui76 : bits(2) @ rs2 : regidx @ 0b10
+mapping clause encdec_compressed = C_SWSP(ui76 @ ui52, rs2) if extension("C") if extension("C")
+  <-> 0b110 @ ui52 : bits(4) @ ui76 : bits(2) @ rs2 : regidx @ 0b10 if extension("C") if extension("C")
 
 function clause execute (C_SWSP(uimm, rs2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b00);
   execute(STORE(imm, rs2, sp, WORD, false, false))
 }
 
-mapping clause assembly = C_SWSP(uimm, rd)
-  <-> "c.swsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm)
+mapping clause assembly = C_SWSP(uimm, rd) if extension("C")
+  <-> "c.swsp" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_6(uimm) if extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_SDSP : (bits(6), regidx)
 
 mapping clause encdec_compressed = C_SDSP(ui86 @ ui53, rs2)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
   <-> 0b111 @ ui53 : bits(3) @ ui86 : bits(3) @ rs2 : regidx @ 0b10
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
 
 function clause execute (C_SDSP(uimm, rs2)) = {
   let imm : bits(12) = zero_extend(uimm @ 0b000);
@@ -546,81 +549,82 @@ function clause execute (C_SDSP(uimm, rs2)) = {
 }
 
 mapping clause assembly = C_SDSP(uimm, rs2)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
   <-> "c.sdsp" ^ spc() ^ reg_name(rs2) ^ sep() ^ hex_bits_6(uimm)
-      if sizeof(xlen) == 64
+      if sizeof(xlen) == 64 & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_JR : (regidx)
 
 mapping clause encdec_compressed = C_JR(rs1)
-      if rs1 != zreg
+      if rs1 != zreg & extension("C")
   <-> 0b100 @ 0b0 @ rs1 : regidx @ 0b00000 @ 0b10
-      if rs1 != zreg
+      if rs1 != zreg & extension("C")
 
 function clause execute (C_JR(rs1)) =
   execute(RISCV_JALR(zero_extend(0b0), rs1, zreg))
 
 mapping clause assembly = C_JR(rs1)
-      if rs1 != zreg
+      if rs1 != zreg & extension("C")
   <-> "c.jr" ^ spc() ^ reg_name(rs1)
-      if rs1 != zreg
+      if rs1 != zreg & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_JALR : (regidx)
 
 mapping clause encdec_compressed = C_JALR(rs1)
-      if rs1 != zreg
+      if rs1 != zreg & extension("C")
   <-> 0b100 @ 0b1 @ rs1 : regidx @ 0b00000 @ 0b10
-      if rs1 != zreg
+      if rs1 != zreg & extension("C")
 
 function clause execute (C_JALR(rs1)) =
   execute(RISCV_JALR(zero_extend(0b0), rs1, ra))
 
 mapping clause assembly = C_JALR(rs1)
-      if rs1 != zreg
+      if rs1 != zreg & extension("C")
   <-> "c.jalr" ^ spc() ^ reg_name(rs1)
-      if rs1 != zreg
+      if rs1 != zreg & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_MV : (regidx, regidx)
 
 mapping clause encdec_compressed = C_MV(rd, rs2)
-      if rd != zreg & rs2 != zreg
+      if rd != zreg & rs2 != zreg & extension("C")
   <-> 0b100 @ 0b0 @ rd : regidx @ rs2 : regidx @ 0b10
-      if rd != zreg & rs2 != zreg
+      if rd != zreg & rs2 != zreg & extension("C")
 
 function clause execute (C_MV(rd, rs2)) =
   execute(RTYPE(rs2, zreg, rd, RISCV_ADD))
 
 mapping clause assembly = C_MV(rd, rs2)
-      if rd != zreg & rs2 != zreg
+      if rd != zreg & rs2 != zreg & extension("C")
   <-> "c.mv" ^ spc() ^ reg_name(rd) ^ sep() ^ reg_name(rs2)
-      if rd != zreg & rs2 != zreg
+      if rd != zreg & rs2 != zreg & extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_EBREAK : unit
 
-mapping clause encdec_compressed = C_EBREAK()
-  <-> 0b100 @ 0b1 @ 0b00000 @ 0b00000 @ 0b10
+mapping clause encdec_compressed = C_EBREAK() if extension("C")
+  <-> 0b100 @ 0b1 @ 0b00000 @ 0b00000 @ 0b10 if extension("C")
 
 function clause execute C_EBREAK() =
   execute(EBREAK())
 
-mapping clause assembly = C_EBREAK() <-> "c.ebreak"
+mapping clause assembly = C_EBREAK() if extension("C")
+   <-> "c.ebreak" if extension("C")
 
 /* ****************************************************************** */
 union clause ast = C_ADD : (regidx, regidx)
 
 mapping clause encdec_compressed = C_ADD(rsd, rs2)
-      if rsd != zreg & rs2 != zreg
+      if rsd != zreg & rs2 != zreg & extension("C")
   <-> 0b100 @ 0b1 @ rsd : regidx @ rs2 : regidx @ 0b10
-      if rsd != zreg & rs2 != zreg
+      if rsd != zreg & rs2 != zreg & extension("C")
 
 function clause execute (C_ADD(rsd, rs2)) =
   execute(RTYPE(rs2, rsd, rsd, RISCV_ADD))
 
 mapping clause assembly = C_ADD(rsd, rs2)
-      if rsd != zreg & rs2 != zreg
+      if rsd != zreg & rs2 != zreg & extension("C")
   <-> "c.add" ^ spc() ^ reg_name(rsd) ^ sep() ^ reg_name(rs2)
-      if rsd != zreg & rs2 != zreg
+      if rsd != zreg & rs2 != zreg & extension("C")

--- a/model/riscv_insts_helper.sail
+++ b/model/riscv_insts_helper.sail
@@ -1,0 +1,29 @@
+-- useful_functions.sail
+
+val extension : (string) -> bool
+
+function extension(ext) = {
+  -- Base ISA extensions
+  match ext {
+    "A" => misa.A() == 0b1,
+    "C" => misa.C() == 0b1,
+    "D" => misa.D() == 0b1,
+    "E" => misa.E() == 0b1,
+    "F" => misa.F() == 0b1,
+    "I" => misa.I() == 0b1,
+    "M" => misa.M() == 0b1,
+    "N" => misa.N() == 0b1,
+    "S" => misa.S() == 0b1,
+    "U" => misa.U() == 0b1,
+    "V" => misa.V() == 0b1,
+    "Zicsr" => misa.CSR() == 0b1,
+    "Zifencei" => misa.IFenceI() == 0b1,
+    "Zim" => misa.M() == 0b1,
+    "Zkr" => misa.Kernel() == 0b1,
+    "Zmedeleg" => misa.MEDELEG() == 0b1,
+    "Zmideleg" => misa.MIDELEG() == 0b1,
+    "Zpmp" => misa.PMP() == 0b1,
+    "Zrelro" => misa.Relro() == 0b1,
+    _ => false
+  }
+}

--- a/model/riscv_insts_zfa.sail
+++ b/model/riscv_insts_zfa.sail
@@ -224,8 +224,8 @@ mapping clause encdec = RISCV_FMINM_H(rs2, rs1, rd)     if haveZfh() & haveZfa()
 
 mapping clause assembly = RISCV_FMINM_H(rs2, rs1, rd)
   <-> "fminm.h" ^ spc() ^ freg_name(rd)
-                ^ spc() ^ freg_name(rs1)
-                ^ spc() ^ freg_name(rs2)
+                ^ sep() ^ freg_name(rs1)
+                ^ sep() ^ freg_name(rs2)
 
 function clause execute (RISCV_FMINM_H(rs2, rs1, rd)) = {
   let rs1_val_H = F_H(rs1);
@@ -254,8 +254,8 @@ mapping clause encdec = RISCV_FMAXM_H(rs2, rs1, rd)     if haveZfh() & haveZfa()
 
 mapping clause assembly = RISCV_FMAXM_H(rs2, rs1, rd)
   <-> "fmaxm.h" ^ spc() ^ freg_name(rd)
-                ^ spc() ^ freg_name(rs1)
-                ^ spc() ^ freg_name(rs2)
+                ^ sep() ^ freg_name(rs1)
+                ^ sep() ^ freg_name(rs2)
 
 function clause execute (RISCV_FMAXM_H(rs2, rs1, rd)) = {
   let rs1_val_H = F_H(rs1);
@@ -284,8 +284,8 @@ mapping clause encdec = RISCV_FMINM_S(rs2, rs1, rd)     if haveZfa()
 
 mapping clause assembly = RISCV_FMINM_S(rs2, rs1, rd)
   <-> "fminm.s" ^ spc() ^ freg_name(rd)
-                ^ spc() ^ freg_name(rs1)
-                ^ spc() ^ freg_name(rs2)
+                ^ sep() ^ freg_name(rs1)
+                ^ sep() ^ freg_name(rs2)
 
 function clause execute (RISCV_FMINM_S(rs2, rs1, rd)) = {
   let rs1_val_S = F_S(rs1);
@@ -314,8 +314,8 @@ mapping clause encdec = RISCV_FMAXM_S(rs2, rs1, rd)     if haveZfa()
 
 mapping clause assembly = RISCV_FMAXM_S(rs2, rs1, rd)
   <-> "fmaxm.s" ^ spc() ^ freg_name(rd)
-                ^ spc() ^ freg_name(rs1)
-                ^ spc() ^ freg_name(rs2)
+                ^ sep() ^ freg_name(rs1)
+                ^ sep() ^ freg_name(rs2)
 
 function clause execute (RISCV_FMAXM_S(rs2, rs1, rd)) = {
   let rs1_val_S = F_S(rs1);
@@ -344,8 +344,8 @@ mapping clause encdec = RISCV_FMINM_D(rs2, rs1, rd)     if haveDExt() & haveZfa(
 
 mapping clause assembly = RISCV_FMINM_D(rs2, rs1, rd)
   <-> "fminm.d" ^ spc() ^ freg_name(rd)
-                ^ spc() ^ freg_name(rs1)
-                ^ spc() ^ freg_name(rs2)
+                ^ sep() ^ freg_name(rs1)
+                ^ sep() ^ freg_name(rs2)
 
 function clause execute (RISCV_FMINM_D(rs2, rs1, rd)) = {
   let rs1_val_D = F(rs1);
@@ -374,8 +374,8 @@ mapping clause encdec = RISCV_FMAXM_D(rs2, rs1, rd)     if haveDExt() & haveZfa(
 
 mapping clause assembly = RISCV_FMAXM_D(rs2, rs1, rd)
   <-> "fmaxm.d" ^ spc() ^ freg_name(rd)
-                ^ spc() ^ freg_name(rs1)
-                ^ spc() ^ freg_name(rs2)
+                ^ sep() ^ freg_name(rs1)
+                ^ sep() ^ freg_name(rs2)
 
 function clause execute (RISCV_FMAXM_D(rs2, rs1, rd)) = {
   let rs1_val_D = F(rs1);
@@ -404,8 +404,8 @@ mapping clause encdec = RISCV_FROUND_H(rs1, rm, rd)                           if
 
 mapping clause assembly = RISCV_FROUND_H(rs1, rm, rd)
   <-> "fround.h" ^ spc() ^ freg_name(rd)
-                 ^ spc() ^ freg_name(rs1)
-                 ^ spc() ^ frm_mnemonic(rm)
+                 ^ sep() ^ freg_name(rs1)
+                 ^ sep() ^ frm_mnemonic(rm)
 
 function clause execute (RISCV_FROUND_H(rs1, rm, rd)) = {
   let rs1_val_H = F_H(rs1);
@@ -432,8 +432,8 @@ mapping clause encdec = RISCV_FROUNDNX_H(rs1, rm, rd)                         if
 
 mapping clause assembly = RISCV_FROUNDNX_H(rs1, rm, rd)
   <-> "froundnx.h" ^ spc() ^ freg_name(rd)
-                   ^ spc() ^ freg_name(rs1)
-                   ^ spc() ^ frm_mnemonic(rm)
+                   ^ sep() ^ freg_name(rs1)
+                   ^ sep() ^ frm_mnemonic(rm)
 
 function clause execute (RISCV_FROUNDNX_H(rs1, rm, rd)) = {
   let rs1_val_H = F_H(rs1);
@@ -460,8 +460,8 @@ mapping clause encdec = RISCV_FROUND_S(rs1, rm, rd)                            i
 
 mapping clause assembly = RISCV_FROUND_S(rs1, rm, rd)
   <-> "fround.s" ^ spc() ^ freg_name(rd)
-                 ^ spc() ^ freg_name(rs1)
-                 ^ spc() ^ frm_mnemonic(rm)
+                 ^ sep() ^ freg_name(rs1)
+                 ^ sep() ^ frm_mnemonic(rm)
 
 function clause execute (RISCV_FROUND_S(rs1, rm, rd)) = {
   let rs1_val_S = F_S(rs1);
@@ -488,8 +488,8 @@ mapping clause encdec = RISCV_FROUNDNX_S(rs1, rm, rd)                         if
 
 mapping clause assembly = RISCV_FROUNDNX_S(rs1, rm, rd)
   <-> "froundnx.s" ^ spc() ^ freg_name(rd)
-                   ^ spc() ^ freg_name(rs1)
-                   ^ spc() ^ frm_mnemonic(rm)
+                   ^ sep() ^ freg_name(rs1)
+                   ^ sep() ^ frm_mnemonic(rm)
 
 function clause execute (RISCV_FROUNDNX_S(rs1, rm, rd)) = {
   let rs1_val_S = F_S(rs1);
@@ -516,8 +516,8 @@ mapping clause encdec = RISCV_FROUND_D(rs1, rm, rd)                            i
 
 mapping clause assembly = RISCV_FROUND_D(rs1, rm, rd)
   <-> "fround.d" ^ spc() ^ freg_name(rd)
-                 ^ spc() ^ freg_name(rs1)
-                 ^ spc() ^ frm_mnemonic(rm)
+                 ^ sep() ^ freg_name(rs1)
+                 ^ sep() ^ frm_mnemonic(rm)
 
 function clause execute (RISCV_FROUND_D(rs1, rm, rd)) = {
   let rs1_val_D = F(rs1);
@@ -544,8 +544,8 @@ mapping clause encdec = RISCV_FROUNDNX_D(rs1, rm, rd)                         if
 
 mapping clause assembly = RISCV_FROUNDNX_D(rs1, rm, rd)
   <-> "froundnx.d" ^ spc() ^ freg_name(rd)
-                   ^ spc() ^ freg_name(rs1)
-                   ^ spc() ^ frm_mnemonic(rm)
+                   ^ sep() ^ freg_name(rs1)
+                   ^ sep() ^ frm_mnemonic(rm)
 
 function clause execute (RISCV_FROUNDNX_D(rs1, rm, rd)) = {
   let rs1_val_D = F_D(rs1);
@@ -572,7 +572,7 @@ mapping clause encdec   = RISCV_FMVH_X_D(rs1, rd)           if haveDExt() & have
 
 mapping clause assembly = RISCV_FMVH_X_D(rs1, rd)
   <-> "fmvh.x.d" ^ spc() ^ reg_name(rd)
-                 ^ spc() ^ freg_name(rs1)
+                 ^ sep() ^ freg_name(rs1)
 
 function clause execute (RISCV_FMVH_X_D(rs1, rd)) = {
   let rs1_val_D           = F_D(rs1)[63..32];
@@ -590,8 +590,8 @@ mapping clause encdec = RISCV_FMVP_D_X(rs2, rs1, rd)        if haveDExt() & have
 
 mapping clause assembly = RISCV_FMVP_D_X(rs2, rs1, rd)
   <-> "fmvp.d.x" ^ spc() ^ freg_name(rd)
-                 ^ spc() ^ reg_name(rs1)
-                 ^ spc() ^ reg_name(rs2)
+                 ^ sep() ^ reg_name(rs1)
+                 ^ sep() ^ reg_name(rs2)
 
 function clause execute (RISCV_FMVP_D_X(rs2, rs1, rd)) = {
   let rs1_val_X     = X(rs1)[31..0];
@@ -617,8 +617,8 @@ mapping clause encdec = RISCV_FLEQ_H(rs2, rs1, rd)               if haveZfh() & 
 
 mapping clause assembly = RISCV_FLEQ_H(rs2, rs1, rd)
   <-> "fleq.h" ^ spc() ^ freg_name(rd)
-               ^ spc() ^ freg_name(rs1)
-               ^ spc() ^ freg_name(rs2)
+               ^ sep() ^ freg_name(rs1)
+               ^ sep() ^ freg_name(rs2)
 
 function clause execute(RISCV_FLEQ_H(rs2, rs1, rd)) = {
   let rs1_val_H = F_H(rs1);
@@ -641,8 +641,8 @@ mapping clause encdec = RISCV_FLTQ_H(rs2, rs1, rd)               if haveZfh() & 
 
 mapping clause assembly = RISCV_FLTQ_H(rs2, rs1, rd)
   <-> "fltq.h" ^ spc() ^ freg_name(rd)
-               ^ spc() ^ freg_name(rs1)
-               ^ spc() ^ freg_name(rs2)
+               ^ sep() ^ freg_name(rs1)
+               ^ sep() ^ freg_name(rs2)
 
 function clause execute(RISCV_FLTQ_H(rs2, rs1, rd)) = {
   let rs1_val_H = F_H(rs1);
@@ -665,8 +665,8 @@ mapping clause encdec = RISCV_FLEQ_S(rs2, rs1, rd)               if haveZfa()
 
 mapping clause assembly = RISCV_FLEQ_S(rs2, rs1, rd)
   <-> "fleq.s" ^ spc() ^ freg_name(rd)
-               ^ spc() ^ freg_name(rs1)
-               ^ spc() ^ freg_name(rs2)
+               ^ sep() ^ freg_name(rs1)
+               ^ sep() ^ freg_name(rs2)
 
 function clause execute(RISCV_FLEQ_S(rs2, rs1, rd)) = {
   let rs1_val_S = F_S(rs1);
@@ -689,8 +689,8 @@ mapping clause encdec = RISCV_FLTQ_S(rs2, rs1, rd)               if haveZfa()
 
 mapping clause assembly = RISCV_FLTQ_S(rs2, rs1, rd)
   <-> "fltq.s" ^ spc() ^ freg_name(rd)
-               ^ spc() ^ freg_name(rs1)
-               ^ spc() ^ freg_name(rs2)
+               ^ sep() ^ freg_name(rs1)
+               ^ sep() ^ freg_name(rs2)
 
 function clause execute(RISCV_FLTQ_S(rs2, rs1, rd)) = {
   let rs1_val_S = F_S(rs1);
@@ -714,8 +714,8 @@ mapping clause encdec = RISCV_FLEQ_D(rs2, rs1, rd)               if haveDExt() &
 
 mapping clause assembly = RISCV_FLEQ_D(rs2, rs1, rd)
   <-> "fleq.d" ^ spc() ^ freg_name(rd)
-               ^ spc() ^ freg_name(rs1)
-               ^ spc() ^ freg_name(rs2)
+               ^ sep() ^ freg_name(rs1)
+               ^ sep() ^ freg_name(rs2)
 
 function clause execute(RISCV_FLEQ_D(rs2, rs1, rd)) = {
   let rs1_val_D = F_D(rs1);
@@ -738,8 +738,8 @@ mapping clause encdec = RISCV_FLTQ_D(rs2, rs1, rd)               if haveDExt() &
 
 mapping clause assembly = RISCV_FLTQ_D(rs2, rs1, rd)
   <-> "fltq.d" ^ spc() ^ freg_name(rd)
-               ^ spc() ^ freg_name(rs1)
-               ^ spc() ^ freg_name(rs2)
+               ^ sep() ^ freg_name(rs1)
+               ^ sep() ^ freg_name(rs2)
 
 function clause execute(RISCV_FLTQ_D(rs2, rs1, rd)) = {
   let rs1_val_D = F_D(rs1);
@@ -823,7 +823,7 @@ mapping clause encdec = RISCV_FCVTMOD_W_D(rs1, rd)          if haveDExt() & have
 
 mapping clause assembly = RISCV_FCVTMOD_W_D(rs1, rd)
   <-> "fcvtmod.w.d" ^ spc() ^ reg_name(rd)
-		    ^ spc() ^ freg_name(rs1)
+		    ^ sep() ^ freg_name(rs1)
 
 function clause execute(RISCV_FCVTMOD_W_D(rs1, rd)) = {
   let rs1_val_D = F_D(rs1);


### PR DESCRIPTION
Implements #4 #5 

I have defined a helper function name `extension` in `riscv_insts_helper` and have included this function to check the extensions of the functions in `riscv_insts_*.sail`  right now it covers "A" and "C" extensions but I will add others also after the feedback. 

@ThinkOpenly tell me if I am on right track or not, I'll  do the required changes in further commits.