### PR TITLE
Asciiize

### DIFF
--- a/model/riscv_insts_vext_vset.sail
+++ b/model/riscv_insts_vext_vset.sail
@@ -122,7 +122,7 @@ function clause execute VSET_TYPE(op, ma, ta, sew, lmul, rs1, rd) = {
     vl = if AVL <= VLMAX then to_bits(sizeof(xlen), AVL)
          else if AVL < 2 * VLMAX then to_bits(sizeof(xlen), (AVL + 1) / 2)
          else to_bits(sizeof(xlen), VLMAX);
-    /* Note: ceil(AVL / 2) ≤ vl ≤ VLMAX when VLMAX < AVL < (2 * VLMAX)
+    /* Note: ceil(AVL / 2) <= vl <= VLMAX when VLMAX < AVL < (2 * VLMAX)
      * TODO: configuration support for either using ceil(AVL / 2) or VLMAX
      */
     X(rd) = vl;
@@ -195,7 +195,7 @@ function clause execute VSETI_TYPE(ma, ta, sew, lmul, uimm, rd) = {
   vl = if AVL <= VLMAX then to_bits(sizeof(xlen), AVL)
        else if AVL < 2 * VLMAX then to_bits(sizeof(xlen), (AVL + 1) / 2)
        else to_bits(sizeof(xlen), VLMAX);
-  /* Note: ceil(AVL / 2) ≤ vl ≤ VLMAX when VLMAX < AVL < (2 * VLMAX)
+  /* Note: ceil(AVL / 2) <= vl <= VLMAX when VLMAX < AVL < (2 * VLMAX)
    * TODO: configuration support for either using ceil(AVL / 2) or VLMAX
    */
   X(rd) = vl;


### PR DESCRIPTION
The JSON backend extracts function code verbatim into JSON format. Unfortunately, the Unicode "Less-than Or Equal To" character, when embedded in JSON, even when escaped using OCaml `String.escaped` does not successfully parse with Python (3.10.12).

For now, at least, revert the Unicode symbol to the ASCII equivalent, which is exactly what is used in the corresponding code and thus might even reduce the chance of confusion.