### PR TITLE
Add more extension as described in Issue #4

### DIFF
--- a/model/riscv_fdext_control.sail
+++ b/model/riscv_fdext_control.sail
@@ -79,9 +79,9 @@
 
 /* val clause ext_is_CSR_defined : (csreg, Privilege) -> bool */
 
-function clause ext_is_CSR_defined (0x001, _) = extension("F") | haveZfinx()
-function clause ext_is_CSR_defined (0x002, _) = extension("F") | haveZfinx()
-function clause ext_is_CSR_defined (0x003, _) = extension("F") | haveZfinx()
+function clause ext_is_CSR_defined (0x001, _) = extension("F") | extension("Zfinx")
+function clause ext_is_CSR_defined (0x002, _) = extension("F") | extension("Zfinx")
+function clause ext_is_CSR_defined (0x003, _) = extension("F") | extension("Zfinx")
 
 function clause ext_read_CSR (0x001) = Some (zero_extend (fcsr.FFLAGS()))
 function clause ext_read_CSR (0x002) = Some (zero_extend (fcsr.FRM()))

--- a/model/riscv_insts_dext.sail
+++ b/model/riscv_insts_dext.sail
@@ -286,13 +286,13 @@ function fle_D   (v1,       v2,        is_quiet) = {
 /* **************************************************************** */
 /* Helper functions for 'encdec()'                                  */
 
-function haveDoubleFPU() -> bool = extension("D") | haveZdinx()
+function haveDoubleFPU() -> bool = extension("D") | extension("Zdinx")
 
 /* RV32Zdinx requires even register pairs; can be omitted for code  */
 /* not used for RV32Zdinx (i.e. RV64-only or D-only).               */
 val validDoubleRegs : forall 'n, 'n > 0. (implicit('n), vector('n, dec, regidx)) -> bool
 function validDoubleRegs(n, regs) = {
-  if haveZdinx() & sizeof(xlen) == 32 then
+  if extension("Zdinx") & sizeof(xlen) == 32 then
     foreach (i from 0 to (n - 1))
       if (regs[i][0] == bitone) then return false;
   true

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -321,7 +321,7 @@ function fle_S   (v1,       v2,        is_quiet) = {
 /* **************************************************************** */
 /* Helper functions for 'encdec()'                                  */
 
-function haveSingleFPU() -> bool = extension("F") | haveZfinx()
+function haveSingleFPU() -> bool = extension("F") | extension("Zfinx")
 
 /* ****************************************************************** */
 /* Floating-point loads                                               */

--- a/model/riscv_insts_zfh.sail
+++ b/model/riscv_insts_zfh.sail
@@ -224,7 +224,7 @@ function fle_H   (v1,       v2,        is_quiet) = {
 /* **************************************************************** */
 /* Helper functions for 'encdec()'                                  */
 
-function haveHalfFPU() -> bool = extension("Zfh") | haveZhinx()
+function haveHalfFPU() -> bool = extension("Zfh") | extension("Zhinx")
 
 /* ****************************************************************** */
 /* Floating-point loads                                               */


### PR DESCRIPTION
This PR aims to continue the remaining work from commit https://github.com/ThinkOpenly/sail-riscv/commit/7c1eae725f945a30a41ab84eee000ec85dcafb0f of issue #4 converting all uses of haveZdinx(), haveZhinx(), haveZfinx() to extension("Zdinx"), extension("Zhinx"), extension("Zfinx") respectively to facilitate parsing.