### PR TITLE
Add names for some instructions within groups

### DIFF
--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -148,7 +148,7 @@ mapping clause assembly = RISCV_JAL(imm, rd)
   <-> "jal" ^ spc() ^ reg_name(rd) ^ sep() ^ hex_bits_21(imm)
 
 /* ****************************************************************** */
-$[name Jump And Link Register]
+$[name jump and link register]
 /*!
  * The target address is obtained by adding the sign-extended 12-bit
  * I-immediate to the register rs1, then setting the
@@ -169,7 +169,7 @@ mapping clause assembly = RISCV_JALR(imm, rs1, rd)
 /* see riscv_jalr_seq.sail or riscv_jalr_rmem.sail for the execute clause. */
 
 /* ****************************************************************** */
-$[name Conditional Branch]
+$[name conditional branch]
 /*!
  * The target address for this branch instruction is determined by combining
  * the sign-extended 13-bit immediate value with the contents of register rs1.
@@ -292,12 +292,18 @@ function clause execute (ITYPE (imm, rs1, rd, op)) = {
 }
 
 mapping itype_mnemonic : iop <-> string = {
-  RISCV_ADDI  <-> "addi",
-  RISCV_SLTI  <-> "slti",
-  RISCV_SLTIU <-> "sltiu",
-  RISCV_XORI  <-> "xori",
-  RISCV_ORI   <-> "ori",
-  RISCV_ANDI  <-> "andi"
+  $[name add immediate]
+    RISCV_ADDI  <-> "addi",
+  $[name set less than immediate]
+    RISCV_SLTI  <-> "slti",
+  $[name set less than immediate unsigned]
+    RISCV_SLTIU <-> "sltiu",
+  $[name XOR immediate]
+    RISCV_XORI  <-> "xori",
+  $[name OR immediate]
+    RISCV_ORI   <-> "ori",
+  $[name AND immediate]
+    RISCV_ANDI  <-> "andi"
 }
 
 mapping clause assembly = ITYPE(imm, rs1, rd, op)


### PR DESCRIPTION
Some instructions are grouped in a single `mapping clause assembly` where the respective mnemonics are embedded within a separate `mapping`.

For instructions which are _not_ grouped, the name of the instruction can be added as an attribute to any of the instruction-specific constructs.

For grouped instructions, the attribute needs to be added to a construct at the granularity of the specific instruction. Here, we attach the attribute within the individual element of the `mapping` that includes the actual instruction mnemonic.

This approach is still insufficient for mnemonics that are constructed:
```
mapping clause assembly = VLSEGTYPE(nf, vm, rs1, width, vd)
  <-> "vl" ^ nfields_string(nf) ^ "e" ^ vlewidth_bitsnumberstr(width) ^ ".v" [...]
```
...so more thought is needed here.

Also, I'm settling on a convention of using lower case (not Leading Caps), at least for now. This matches how the instruction names are written in the ISA specification, at least for those instructions for which the name is actually provided. :-/