### PR TITLE
ci/cd: upgrade actions to v4 to avoid NodeJS warning

### DIFF
--- a/.github/workflows/unicode-check.yml
+++ b/.github/workflows/unicode-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check for unicode in sail files
         run: |


### PR DESCRIPTION
This PR upgrades `actions/checkout` from `v2` to `v4` in the `check-unicode.yml` workflow, addressing warnings caused by `Node.js 12` deprecation. The upgrade uses `Node.js 16`, eliminating the warnings.
